### PR TITLE
including unistd.h so the syscall close becomes known.

### DIFF
--- a/nxcl/lib/notQt.h
+++ b/nxcl/lib/notQt.h
@@ -32,6 +32,7 @@
 #include <vector>
 #include <string>
 #include <fstream>
+#include <unistd.h>
 extern "C" {
 #include <sys/poll.h>
 }


### PR DESCRIPTION
Avoids error: 'clo...se' was not declared in this scope
